### PR TITLE
[CM] Replace CmFastMemCopy with CmSafeMemCopy in some places

### DIFF
--- a/media_driver/agnostic/common/cm/cm_device_rt.cpp
+++ b/media_driver/agnostic/common/cm/cm_device_rt.cpp
@@ -2547,7 +2547,7 @@ int32_t CmDeviceRT::RegisterSampler8x8State(
         case CM_SAMPLER8X8_CONV:
             dst = (void *)&(param.sampler8x8State.convolveState);
             src = (void *)sampler8x8State.conv;
-            CmFastMemCopy( dst, src, sizeof( CM_CONVOLVE_STATE_MSG));
+            CmSafeMemCopy( dst, src, sizeof( CM_CONVOLVE_STATE_MSG));
             break;
 
         case CM_SAMPLER8X8_MISC:

--- a/media_driver/agnostic/common/cm/cm_event_rt.cpp
+++ b/media_driver/agnostic/common/cm/cm_event_rt.cpp
@@ -651,7 +651,7 @@ CM_RT_API  int32_t CmEventRT::GetSurfaceDetails(uint32_t kernIndex, uint32_t sur
         return CM_INVALID_ARG_VALUE;
     }
 
-    CmFastMemCopy(&outDetails,tempSurfInfo,sizeof(CM_SURFACE_DETAILS));
+    CmSafeMemCopy(&outDetails,tempSurfInfo,sizeof(CM_SURFACE_DETAILS));
     return CM_SUCCESS;
 }
 
@@ -690,7 +690,7 @@ int32_t CmEventRT::SetSurfaceDetails(CM_HAL_SURFACE_ENTRY_INFO_ARRAYS surfaceInf
         else
         {
             m_surEntryInfoArrays.surfEntryInfosArray[i].surfEntryInfos=temp;
-            CmFastMemCopy(m_surEntryInfoArrays.surfEntryInfosArray[i].surfEntryInfos,
+            CmSafeMemCopy(m_surEntryInfoArrays.surfEntryInfosArray[i].surfEntryInfos,
                                          surfaceInfo.surfEntryInfosArray[i].surfEntryInfos,
                                          surfEntryNum*sizeof(CM_SURFACE_DETAILS));
          }
@@ -709,7 +709,7 @@ int32_t CmEventRT::SetSurfaceDetails(CM_HAL_SURFACE_ENTRY_INFO_ARRAYS surfaceInf
             else
             {
                 m_surEntryInfoArrays.surfEntryInfosArray[i].globalSurfInfos=temp;
-                CmFastMemCopy(m_surEntryInfoArrays.surfEntryInfosArray[i].globalSurfInfos,
+                CmSafeMemCopy(m_surEntryInfoArrays.surfEntryInfosArray[i].globalSurfInfos,
                                              surfaceInfo.surfEntryInfosArray[i].globalSurfInfos,
                                              globalSurfNum*sizeof(CM_SURFACE_DETAILS));
              }

--- a/media_driver/agnostic/common/cm/cm_kernel_rt.cpp
+++ b/media_driver/agnostic/common/cm/cm_kernel_rt.cpp
@@ -456,7 +456,7 @@ int32_t CmKernelRT::Initialize( const char* kernelName, const char* options )
                 return CM_OUT_OF_HOST_MEMORY;
 
             }
-            CmFastMemCopy( m_options, options, length);
+            CmSafeMemCopy( m_options, options, length);
             m_options[ length ] = '\0';
 
             char* tmp = strstr( m_options, "nocurbe" );
@@ -533,7 +533,7 @@ int32_t CmKernelRT::Initialize( const char* kernelName, const char* options )
                     CM_ASSERTMESSAGE("Error: Out of system memory.");
                     return CM_OUT_OF_HOST_MEMORY;
                 }
-                CmFastMemCopy(string, globalString->getString(), stringLength);
+                CmSafeMemCopy(string, globalString->getString(), stringLength);
                 string[stringLength] = '\0';
                 m_kernelInfo->globalStrings[i] = string;
                 i++;
@@ -728,11 +728,11 @@ int32_t CmKernelRT::Initialize( const char* kernelName, const char* options )
             {
                 if (useVisaApi)
                 {
-                    CmFastMemCopy(m_kernelInfo->kernelASMName, attribute->getValue(), size);
+                    CmSafeMemCopy(m_kernelInfo->kernelASMName, attribute->getValue(), size);
                 }
                 else
                 {
-                    CmFastMemCopy(m_kernelInfo->kernelASMName, &buf[bytePosition], size);
+                    CmSafeMemCopy(m_kernelInfo->kernelASMName, &buf[bytePosition], size);
                     bytePosition += size;
                 }
             }
@@ -1910,7 +1910,7 @@ finish:
 
             arg.unitCount = 1;
 
-            CmFastMemCopy((void *)arg.value, value, size);
+            CmSafeMemCopy((void *)arg.value, value, size);
 
             if((( m_args[ index ].unitKind == ARG_KIND_SURFACE ) || // first time
                  ( m_args[ index ].unitKind == ARG_KIND_SURFACE_1D ) ||
@@ -1938,7 +1938,7 @@ finish:
                     CM_ASSERTMESSAGE("Error: Pointer to surface index value is null.");
                     return CM_NULL_POINTER;
                 }
-                CmFastMemCopy((void *)arg.surfIndex, surfIndexValue, size / sizeof(int32_t) * sizeof(uint16_t));
+                CmSafeMemCopy((void *)arg.surfIndex, surfIndexValue, size / sizeof(int32_t) * sizeof(uint16_t));
             }
 
             if (m_args[index].unitKind == ARG_KIND_SAMPLER)
@@ -1961,7 +1961,7 @@ finish:
             }
             if( memcmp( (void *)arg.value, value, size ) != 0 )
             {
-                CmFastMemCopy((void *)arg.value, value, size);
+                CmSafeMemCopy((void *)arg.value, value, size);
                 m_dirty |= CM_KERNEL_DATA_KERNEL_ARG_DIRTY;
                 arg.isDirty = true;
             }
@@ -1984,7 +1984,7 @@ finish:
                     CM_ASSERTMESSAGE("Error: Pointer to surface index value is null.");
                     return CM_NULL_POINTER;
                 }
-                CmFastMemCopy((void *)arg.surfIndex, surfIndexValue, size/sizeof(int32_t) * sizeof(uint16_t));
+                CmSafeMemCopy((void *)arg.surfIndex, surfIndexValue, size/sizeof(int32_t) * sizeof(uint16_t));
             }
 
             if (m_args[index].unitKind == ARG_KIND_SAMPLER)
@@ -2023,7 +2023,7 @@ finish:
             uint8_t *threadValue = ( uint8_t *)arg.value;
             threadValue += offset;
 
-            CmFastMemCopy(threadValue, value, size);
+            CmSafeMemCopy(threadValue, value, size);
             if((( m_args[ index ].unitKind == ARG_KIND_SURFACE ) || // first time
                  ( m_args[ index ].unitKind == ARG_KIND_SURFACE_1D ) ||
                  ( m_args[ index ].unitKind == ARG_KIND_SURFACE_2D ) ||
@@ -2050,7 +2050,7 @@ finish:
                     CM_ASSERTMESSAGE("Error: Pointer to surface index value is null.");
                     return CM_NULL_POINTER;
                 }
-                CmFastMemCopy((void *)(arg.surfIndex + size/sizeof(uint32_t)  * nThreadID), surfIndexValue, size/sizeof(uint32_t) * sizeof(uint16_t));
+                CmSafeMemCopy((void *)(arg.surfIndex + size/sizeof(uint32_t)  * nThreadID), surfIndexValue, size/sizeof(uint32_t) * sizeof(uint16_t));
             }
             m_perThreadArgExists = true;
         }
@@ -2068,7 +2068,7 @@ finish:
 
             if( memcmp( threadValue, value, size ) != 0 )
             {
-                CmFastMemCopy(threadValue, value, size);
+                CmSafeMemCopy(threadValue, value, size);
                 m_dirty |= CM_KERNEL_DATA_THREAD_ARG_DIRTY;
                 arg.isDirty = true;
             }
@@ -2090,7 +2090,7 @@ finish:
                     CM_ASSERTMESSAGE("Error: Pointer to surface index value is null.");
                     return CM_NULL_POINTER;
                 }
-                CmFastMemCopy((void *)(arg.surfIndex + size/sizeof(uint32_t)  * nThreadID), surfIndexValue, size/sizeof(uint32_t) * sizeof(uint16_t));
+                CmSafeMemCopy((void *)(arg.surfIndex + size/sizeof(uint32_t)  * nThreadID), surfIndexValue, size/sizeof(uint32_t) * sizeof(uint16_t));
             }
         }
     }
@@ -2526,14 +2526,14 @@ int32_t CmKernelRT::CreateMovInstructions( uint32_t &movInstNum, uint8_t *&codeD
         {
             movInst->ClearDebug();
         }
-        CmFastMemCopy(codeDst + j * CM_MOVE_INSTRUCTION_SIZE, movInst->GetBinary(), CM_MOVE_INSTRUCTION_SIZE);
+        CmSafeMemCopy(codeDst + j * CM_MOVE_INSTRUCTION_SIZE, movInst->GetBinary(), CM_MOVE_INSTRUCTION_SIZE);
         CmSafeDelete(movInst); // delete each element in movInsts
     }
     movInsts.Delete();
 
     if(addInstNum != 0)
     {
-       CmFastMemCopy(codeDst + movInstNum * CM_MOVE_INSTRUCTION_SIZE, addInstDW, CM_MOVE_INSTRUCTION_SIZE);
+       CmSafeMemCopy(codeDst + movInstNum * CM_MOVE_INSTRUCTION_SIZE, addInstDW, CM_MOVE_INSTRUCTION_SIZE);
 
        movInstNum += addInstNum; // take add Y instruction into consideration
     }
@@ -2605,7 +2605,7 @@ int32_t CmKernelRT::CreateThreadArgData(
     {
         if (cmArgs[threadArgIndex].value)
         {
-            CmFastMemCopy(kernelArg->firstValue, cmArgs[threadArgIndex].value, threadArgCount * threadArgSize);
+            CmSafeMemCopy(kernelArg->firstValue, cmArgs[threadArgIndex].value, threadArgCount * threadArgSize);
         }
         goto finish;
     }
@@ -2628,17 +2628,17 @@ int32_t CmKernelRT::CreateThreadArgData(
                 uint32_t offset = threadSpaceUnit[boardOrder[index]].threadId;
                 uint8_t *argSrc = (uint8_t*)cmArgs[threadArgIndex].value + offset * threadArgSize;
                 uint8_t *argDst = kernelArg->firstValue + index * threadArgSize;
-                CmFastMemCopy(argDst, argSrc, threadArgSize);
+                CmSafeMemCopy(argDst, argSrc, threadArgSize);
             }
         }
         else
         {
-           CmFastMemCopy(kernelArg->firstValue, cmArgs[ threadArgIndex ].value, threadArgCount * threadArgSize);
+           CmSafeMemCopy(kernelArg->firstValue, cmArgs[ threadArgIndex ].value, threadArgCount * threadArgSize);
         }
     }
     else
     {
-        CmFastMemCopy(kernelArg->firstValue, cmArgs[ threadArgIndex ].value, threadArgCount * threadArgSize);
+        CmSafeMemCopy(kernelArg->firstValue, cmArgs[ threadArgIndex ].value, threadArgCount * threadArgSize);
     }
 
 finish:
@@ -2814,7 +2814,7 @@ int32_t CmKernelRT::CreateTempArgs(
                         {
                             surfaces[s] = *(uint32_t *)((uint32_t *)m_args[j].value + k + numSurfaces * s);
                         }
-                        CmFastMemCopy(tempArgs[j + increasedArgs + k].value, surfaces, sizeof(int32_t) * m_args[j].unitCount);
+                        CmSafeMemCopy(tempArgs[j + increasedArgs + k].value, surfaces, sizeof(int32_t) * m_args[j].unitCount);
                         tempArgs[j + increasedArgs + k].unitOffsetInPayload = m_args[j].unitOffsetInPayload + 4 * k;
                         tempArgs[j + increasedArgs + k].unitOffsetInPayloadOrig = (uint16_t)-1;
                     }
@@ -3024,7 +3024,7 @@ int32_t CmKernelRT::CreateThreadSpaceParam(
 
     if(dependency != nullptr)
     {
-        CmFastMemCopy(&kernelThreadSpaceParam->dependencyInfo, dependency, sizeof(CM_HAL_DEPENDENCY));
+        CmSafeMemCopy(&kernelThreadSpaceParam->dependencyInfo, dependency, sizeof(CM_HAL_DEPENDENCY));
     }
 
     if( threadSpace->CheckWalkingParametersSet( ) )
@@ -3080,7 +3080,7 @@ int32_t CmKernelRT::CreateThreadSpaceParam(
             kernelThreadSpaceParam->dispatchInfo.numWaves = dispatchInfo.numWaves;
             kernelThreadSpaceParam->dispatchInfo.numThreadsInWave = MOS_NewArray(uint32_t, dispatchInfo.numWaves);
             CMCHK_NULL_RETURN(kernelThreadSpaceParam->dispatchInfo.numThreadsInWave, CM_OUT_OF_HOST_MEMORY);
-            CmFastMemCopy(kernelThreadSpaceParam->dispatchInfo.numThreadsInWave,
+            CmSafeMemCopy(kernelThreadSpaceParam->dispatchInfo.numThreadsInWave,
                 dispatchInfo.numThreadsInWave, dispatchInfo.numWaves*sizeof(uint32_t));
 
          }
@@ -3779,7 +3779,7 @@ int32_t CmKernelRT::CreateKernelDataInternal(
 
     if (m_samplerBtiCount != 0)
     {
-        CmFastMemCopy((void*)halKernelParam->samplerBTIParam.samplerInfo, (void*)m_samplerBtiEntry, sizeof(m_samplerBtiEntry));
+        CmSafeMemCopy((void*)halKernelParam->samplerBTIParam.samplerInfo, (void*)m_samplerBtiEntry, sizeof(m_samplerBtiEntry));
         halKernelParam->samplerBTIParam.samplerCount = m_samplerBtiCount;
 
         CmSafeMemSet(m_samplerBtiEntry, 0, sizeof(m_samplerBtiEntry));
@@ -4106,7 +4106,7 @@ int32_t CmKernelRT::CreateKernelDataInternal(
 
     if ( m_samplerBtiCount != 0 )
     {
-        CmFastMemCopy( ( void* )halKernelParam->samplerBTIParam.samplerInfo, ( void* )m_samplerBtiEntry, sizeof( m_samplerBtiEntry ) );
+        CmSafeMemCopy( ( void* )halKernelParam->samplerBTIParam.samplerInfo, ( void* )m_samplerBtiEntry, sizeof( m_samplerBtiEntry ) );
         halKernelParam->samplerBTIParam.samplerCount = m_samplerBtiCount;
 
         CmSafeMemSet(m_samplerBtiEntry, 0, sizeof(m_samplerBtiEntry));
@@ -4267,7 +4267,7 @@ int32_t CmKernelRT::UpdateKernelData(
                         for (uint32_t kk = 0; kk < numSurfaces; kk++)
                         {
                             CM_ASSERT(halKernelParam->argParams[argIndex + kk].firstValue != nullptr);
-                            CmFastMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
+                            CmSafeMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
                                 m_args[orgArgIndex].value + kk*sizeof(uint32_t), sizeof(uint32_t));
                             halKernelParam->argParams[argIndex + kk].aliasIndex = m_args[orgArgIndex].aliasIndex;
                             halKernelParam->argParams[argIndex + kk].aliasCreated = m_args[orgArgIndex].aliasCreated;
@@ -4288,7 +4288,7 @@ int32_t CmKernelRT::UpdateKernelData(
                     else
                     {
                         CM_ASSERT(halKernelParam->argParams[argIndex].firstValue != nullptr);
-                        CmFastMemCopy(halKernelParam->argParams[argIndex].firstValue,
+                        CmSafeMemCopy(halKernelParam->argParams[argIndex].firstValue,
                                 m_args[ orgArgIndex ].value, sizeof(uint32_t));
                         halKernelParam->argParams[argIndex].kind = (CM_HAL_KERNEL_ARG_KIND)m_args[ orgArgIndex ].unitKind;
                         halKernelParam->argParams[argIndex].aliasIndex   = m_args[orgArgIndex].aliasIndex;
@@ -4308,7 +4308,7 @@ int32_t CmKernelRT::UpdateKernelData(
                         {
                             surfaces[s] = *(uint32_t *)((uint32_t *)m_args[orgArgIndex].value + kk + numSurfaces * s);
                         }
-                        CmFastMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
+                        CmSafeMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
                             surfaces, sizeof(uint32_t) * m_args[orgArgIndex].unitCount);
 
                         halKernelParam->argParams[argIndex + kk].kind = (CM_HAL_KERNEL_ARG_KIND)m_args[ orgArgIndex ].unitKind;
@@ -4337,7 +4337,7 @@ int32_t CmKernelRT::UpdateKernelData(
                         MosSafeDeleteArray(halKernelParam->argParams[argIndex + kk].firstValue);
                         halKernelParam->argParams[argIndex + kk].firstValue = MOS_NewArray(uint8_t, vmeSize);
                         CM_ASSERT(halKernelParam->argParams[argIndex + kk].firstValue != nullptr);
-                        CmFastMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
+                        CmSafeMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
                             m_args[orgArgIndex].value + vmeSurfOffset, vmeSize);
 
                         halKernelParam->argParams[argIndex + kk].kind = (CM_HAL_KERNEL_ARG_KIND)m_args[orgArgIndex].unitKind;
@@ -4379,7 +4379,7 @@ int32_t CmKernelRT::UpdateKernelData(
 
         if(dependency != nullptr)
         {
-            CmFastMemCopy(&cmKernelThreadSpaceParam->dependencyInfo, dependency, sizeof(CM_HAL_DEPENDENCY));
+            CmSafeMemCopy(&cmKernelThreadSpaceParam->dependencyInfo, dependency, sizeof(CM_HAL_DEPENDENCY));
         }
 
         if( m_threadSpace->CheckWalkingParametersSet() )
@@ -4423,7 +4423,7 @@ int32_t CmKernelRT::UpdateKernelData(
                 if (cmKernelThreadSpaceParam->dispatchInfo.numWaves >= dispatchInfo.numWaves)
                 {
                     cmKernelThreadSpaceParam->dispatchInfo.numWaves = dispatchInfo.numWaves;
-                    CmFastMemCopy(cmKernelThreadSpaceParam->dispatchInfo.numThreadsInWave, dispatchInfo.numThreadsInWave, dispatchInfo.numWaves*sizeof(uint32_t));
+                    CmSafeMemCopy(cmKernelThreadSpaceParam->dispatchInfo.numThreadsInWave, dispatchInfo.numThreadsInWave, dispatchInfo.numWaves*sizeof(uint32_t));
                 }
                 else
                 {
@@ -4431,7 +4431,7 @@ int32_t CmKernelRT::UpdateKernelData(
                     MosSafeDeleteArray(cmKernelThreadSpaceParam->dispatchInfo.numThreadsInWave);
                     cmKernelThreadSpaceParam->dispatchInfo.numThreadsInWave = MOS_NewArray(uint32_t, dispatchInfo.numWaves);
                     CMCHK_NULL_RETURN(cmKernelThreadSpaceParam->dispatchInfo.numThreadsInWave, CM_OUT_OF_HOST_MEMORY);
-                    CmFastMemCopy(cmKernelThreadSpaceParam->dispatchInfo.numThreadsInWave, dispatchInfo.numThreadsInWave, dispatchInfo.numWaves*sizeof(uint32_t));
+                    CmSafeMemCopy(cmKernelThreadSpaceParam->dispatchInfo.numThreadsInWave, dispatchInfo.numThreadsInWave, dispatchInfo.numWaves*sizeof(uint32_t));
                 }
             }
         }
@@ -4451,7 +4451,7 @@ int32_t CmKernelRT::UpdateKernelData(
                 halKernelParam->indirectDataParam.indirectData = MOS_NewArray(uint8_t, m_usKernelPayloadDataSize);
                 CMCHK_NULL_RETURN(halKernelParam->indirectDataParam.indirectData, CM_OUT_OF_HOST_MEMORY);
             }
-            CmFastMemCopy(halKernelParam->indirectDataParam.indirectData, (void *)m_kernelPayloadData, m_usKernelPayloadDataSize);
+            CmSafeMemCopy(halKernelParam->indirectDataParam.indirectData, (void *)m_kernelPayloadData, m_usKernelPayloadDataSize);
         }
 
         if(m_usKernelPayloadSurfaceCount != 0)
@@ -4463,7 +4463,7 @@ int32_t CmKernelRT::UpdateKernelData(
                 CMCHK_NULL_RETURN(halKernelParam->indirectDataParam.surfaceInfo, CM_OUT_OF_HOST_MEMORY);
 
             }
-            CmFastMemCopy((void*)halKernelParam->indirectDataParam.surfaceInfo, (void*)m_IndirectSurfaceInfoArray,
+            CmSafeMemCopy((void*)halKernelParam->indirectDataParam.surfaceInfo, (void*)m_IndirectSurfaceInfoArray,
                              m_usKernelPayloadSurfaceCount * sizeof(CM_INDIRECT_SURFACE_INFO));
             //clear m_IndirectSurfaceInfoArray every enqueue
             CmSafeMemSet(m_IndirectSurfaceInfoArray, 0, m_usKernelPayloadSurfaceCount * sizeof(CM_INDIRECT_SURFACE_INFO));
@@ -4475,7 +4475,7 @@ int32_t CmKernelRT::UpdateKernelData(
     {
         if ( m_samplerBtiCount != 0 )
         {
-            CmFastMemCopy( ( void* )halKernelParam->samplerBTIParam.samplerInfo, ( void* )m_samplerBtiEntry, sizeof( m_samplerBtiEntry ) );
+            CmSafeMemCopy( ( void* )halKernelParam->samplerBTIParam.samplerInfo, ( void* )m_samplerBtiEntry, sizeof( m_samplerBtiEntry ) );
             halKernelParam->samplerBTIParam.samplerCount = m_samplerBtiCount;
 
             CmSafeMemSet(m_samplerBtiEntry, 0, sizeof(m_samplerBtiEntry));
@@ -4578,7 +4578,7 @@ int32_t CmKernelRT::UpdateKernelData(
                         for(uint32_t kk=0;  kk< numSurfaces ; kk++)
                         {
                             CM_ASSERT(halKernelParam->argParams[argIndex + kk].firstValue != nullptr);
-                            CmFastMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
+                            CmSafeMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
                             m_args[ orgArgIndex ].value + kk*sizeof(uint32_t), sizeof(uint32_t));
 
                             if (!m_args[orgArgIndex].surfIndex[kk])
@@ -4597,7 +4597,7 @@ int32_t CmKernelRT::UpdateKernelData(
                     else
                     {
                         CM_ASSERT(halKernelParam->argParams[argIndex].firstValue != nullptr);
-                        CmFastMemCopy(halKernelParam->argParams[argIndex].firstValue,
+                        CmSafeMemCopy(halKernelParam->argParams[argIndex].firstValue,
                             m_args[orgArgIndex].value, sizeof(uint32_t));
 
                         halKernelParam->argParams[argIndex].kind = (CM_HAL_KERNEL_ARG_KIND)m_args[orgArgIndex].unitKind;
@@ -4620,7 +4620,7 @@ int32_t CmKernelRT::UpdateKernelData(
                         MosSafeDeleteArray(halKernelParam->argParams[argIndex + kk].firstValue);
                         halKernelParam->argParams[argIndex + kk].firstValue = MOS_NewArray(uint8_t, vmeSize);
                         CM_ASSERT(halKernelParam->argParams[argIndex + kk].firstValue != nullptr);
-                        CmFastMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
+                        CmSafeMemCopy(halKernelParam->argParams[argIndex + kk].firstValue,
                             m_args[orgArgIndex].value + vmeSurfOffset, vmeSize);
 
                         halKernelParam->argParams[argIndex + kk].kind = (CM_HAL_KERNEL_ARG_KIND)m_args[orgArgIndex].unitKind;
@@ -4645,7 +4645,7 @@ int32_t CmKernelRT::UpdateKernelData(
     {
         if ( m_samplerBtiCount != 0 )
         {
-            CmFastMemCopy( ( void* )halKernelParam->samplerBTIParam.samplerInfo, ( void* )m_samplerBtiEntry, sizeof( m_samplerBtiEntry ) );
+            CmSafeMemCopy( ( void* )halKernelParam->samplerBTIParam.samplerInfo, ( void* )m_samplerBtiEntry, sizeof( m_samplerBtiEntry ) );
             halKernelParam->samplerBTIParam.samplerCount = m_samplerBtiCount;
 
             CmSafeMemSet(m_samplerBtiEntry, 0, sizeof(m_samplerBtiEntry));
@@ -4703,12 +4703,12 @@ int32_t CmKernelRT::CreateKernelIndirectData(
 
     if(m_usKernelPayloadDataSize != 0)
     {
-        CmFastMemCopy(halIndirectData->indirectData, (void *)m_kernelPayloadData, m_usKernelPayloadDataSize);
+        CmSafeMemCopy(halIndirectData->indirectData, (void *)m_kernelPayloadData, m_usKernelPayloadDataSize);
     }
 
     if(m_usKernelPayloadSurfaceCount != 0)
     {
-        CmFastMemCopy((void*)halIndirectData->surfaceInfo, (void*)m_IndirectSurfaceInfoArray,
+        CmSafeMemCopy((void*)halIndirectData->surfaceInfo, (void*)m_IndirectSurfaceInfoArray,
                     m_usKernelPayloadSurfaceCount * sizeof(CM_INDIRECT_SURFACE_INFO));
         //clear m_IndirectSurfaceInfoArray every enqueue
         CmSafeMemSet(m_IndirectSurfaceInfoArray, 0, m_usKernelPayloadSurfaceCount * sizeof(CM_INDIRECT_SURFACE_INFO));

--- a/media_driver/agnostic/common/cm/cm_mem.h
+++ b/media_driver/agnostic/common/cm/cm_mem.h
@@ -638,7 +638,7 @@ inline void CmFastMemCopy( void* dst, const   void* src, const size_t bytes )
     // Get the number of DQWORDs to be copied
     const size_t doubleQuadWords = count / sizeof(DQWORD);
 
-    if( doubleQuadWords )
+    if( count >= CM_CPU_FASTCOPY_THRESHOLD && doubleQuadWords )
     {
         FastMemCopy_SSE2( cacheDst, cacheSrc, doubleQuadWords );
 
@@ -675,7 +675,7 @@ inline void CmFastMemCopyWC( void* dst,   const void* src, const size_t bytes )
 
   size_t count = bytes;
 
-  if( count >= sizeof(DQWORD) )
+  if( count >= CM_CPU_FASTCOPY_THRESHOLD )
   {
     const size_t doubleQuadwordAlignBytes =
       GetAlignmentOffset( cacheDst, sizeof(DQWORD) );

--- a/media_driver/agnostic/common/cm/cm_program.cpp
+++ b/media_driver/agnostic/common/cm/cm_program.cpp
@@ -224,7 +224,7 @@ int32_t CmProgramRT::Initialize( void* cisaCode, const uint32_t cisaCodeSize, co
                 return CM_OUT_OF_HOST_MEMORY;
 
             }
-            CmFastMemCopy( m_options, options, length);
+            CmSafeMemCopy( m_options, options, length);
             m_options[ length ] = '\0';
 
             if(strstr(options, "nojitter"))
@@ -414,12 +414,12 @@ int32_t CmProgramRT::Initialize( void* cisaCode, const uint32_t cisaCodeSize, co
         {
             kernel = header->getKernelInfo()[i];
             nameLen = kernel->getNameLen();
-            CmFastMemCopy(kernInfo->kernelName, kernel->getName(), nameLen);
+            CmSafeMemCopy(kernInfo->kernelName, kernel->getName(), nameLen);
         }
         else
         {
             READ_FIELD_FROM_BUF(nameLen, uint8_t);
-            CmFastMemCopy(kernInfo->kernelName, buf + bytePos, nameLen);
+            CmSafeMemCopy(kernInfo->kernelName, buf + bytePos, nameLen);
             // move bytePos to the right index
             bytePos += nameLen;
         }

--- a/media_driver/agnostic/common/cm/cm_sampler8x8_state_rt.cpp
+++ b/media_driver/agnostic/common/cm/cm_sampler8x8_state_rt.cpp
@@ -93,13 +93,13 @@ CmSampler8x8State_RT::CmSampler8x8State_RT( const CM_SAMPLER_8X8_DESCR& sampleSt
 
     if(sampleState.stateType == CM_SAMPLER8X8_AVS)
     {
-        CmFastMemCopy( &this->m_avsState,  sampleState.avs, sizeof(CM_AVS_STATE_MSG) );
+        CmSafeMemCopy( &this->m_avsState,  sampleState.avs, sizeof(CM_AVS_STATE_MSG) );
     } else if(sampleState.stateType == CM_SAMPLER8X8_CONV)
     {
-        CmFastMemCopy( &this->m_convolveState,  sampleState.conv, sizeof(CM_CONVOLVE_STATE_MSG) );
+        CmSafeMemCopy( &this->m_convolveState,  sampleState.conv, sizeof(CM_CONVOLVE_STATE_MSG) );
     } else if(sampleState.stateType == CM_SAMPLER8X8_MISC)
     {
-        CmFastMemCopy( &this->m_miscState,  sampleState.misc, sizeof(CM_MISC_STATE_MSG) );
+        CmSafeMemCopy( &this->m_miscState,  sampleState.misc, sizeof(CM_MISC_STATE_MSG) );
     }  else {
         CM_ASSERTMESSAGE("Error: Invalid sampler8x8 state type.")
     }

--- a/media_driver/agnostic/common/cm/cm_task_internal.cpp
+++ b/media_driver/agnostic/common/cm/cm_task_internal.cpp
@@ -1640,7 +1640,7 @@ int32_t CmTaskInternal::SetPowerOption( PCM_POWER_OPTION powerOption )
         CM_ASSERTMESSAGE("Error: Pointer to power option is null.");
         return CM_NULL_POINTER;
     }
-    CmFastMemCopy( &m_powerOption, powerOption, sizeof( m_powerOption ) );
+    CmSafeMemCopy( &m_powerOption, powerOption, sizeof( m_powerOption ) );
     return CM_SUCCESS;
 }
 
@@ -1888,7 +1888,7 @@ int32_t CmTaskInternal::SetProperty(CM_TASK_CONFIG * taskConfig)
         CM_ASSERTMESSAGE("Error: Pointer to task config is null.");
         return CM_NULL_POINTER;
     }
-    CmFastMemCopy(&m_taskConfig, taskConfig, sizeof(m_taskConfig));
+    CmSafeMemCopy(&m_taskConfig, taskConfig, sizeof(m_taskConfig));
     return CM_SUCCESS;
 }
 

--- a/media_driver/linux/common/cm/cm_mem_os.h
+++ b/media_driver/linux/common/cm/cm_mem_os.h
@@ -61,6 +61,8 @@ typedef uintptr_t           UINT_PTR;
     #define throw(...)
 #endif
 
+#define CM_CPU_FASTCOPY_THRESHOLD 1024
+
 /*****************************************************************************\
 Inline Function:
     Prefetch
@@ -155,7 +157,7 @@ inline void CmFastMemCopyFromWC( void* dst, const void* src, const size_t bytes,
 
         size_t count = bytes;
 
-        if( count >= sizeof(DHWORD) )
+        if( count >= CM_CPU_FASTCOPY_THRESHOLD )
         {
             //Streaming Load must be 16-byte aligned but should
             //be 64-byte aligned for optimal performance


### PR DESCRIPTION
CmFastMemCopy was designed to accelerate copying large size of memory
with SSE. In this commit, we use CmSafeMemCopy in places where only
small size of memory is copied.

Signed-off-by: Kelvin Hu <kelvin.hu@intel.com>