### PR TITLE
add missing break in switch case

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -3902,6 +3902,7 @@ VAStatus DdiMedia_CreateImage(
             break;
         case VA_FOURCC_YUY2:
             vaimg->num_planes = 1;
+            vaimg->format.bits_per_pixel = 16;
             vaimg->pitches[0] = gmmPitch;
             break;
         case VA_FOURCC_NV12:
@@ -3943,6 +3944,7 @@ VAStatus DdiMedia_CreateImage(
             vaimg->pitches[0] = vaimg->pitches[1] = vaimg->pitches[2] = gmmPitch;
             vaimg->offsets[1] = gmmPitch * gmmHeight;
             vaimg->offsets[2] = vaimg->offsets[1] + gmmPitch * gmmHeight / 2;
+            break;
         case VA_FOURCC_RGBP:
             vaimg->format.bits_per_pixel = 24;
             vaimg->num_planes = 3;


### PR DESCRIPTION
missing break when the image is 422V

Signed-off-by: XinfengZhang <carl.zhang@intel.com>